### PR TITLE
Valid GTM ID

### DIFF
--- a/src/components/GoogleTagManager.tsx
+++ b/src/components/GoogleTagManager.tsx
@@ -7,6 +7,7 @@ import {
   getScriptQueryString,
   GoogleTagManagerArgs,
   pageview,
+  isValidGtmId,
 } from '../utils/gtm';
 import { usePathname, useSearchParams } from 'next/navigation';
 
@@ -22,6 +23,11 @@ const GoogleTagManager: FC<GoogleTagManagerArgs> = ({
   useEffect(() => {
     if (pathname) pageview(pathname);
   }, [pathname, searchParams]);
+  
+  if (!isValidGtmId(id)) {
+    console.warn('next-google-tag-manager: It looks like the ID of your Google Tag Manager container is not valid. For more information please check https://github.com/XD2Sketch/next-google-tag-manager#usage');
+    return null
+  }
 
   return (
     <>

--- a/src/utils/gtm.ts
+++ b/src/utils/gtm.ts
@@ -18,6 +18,11 @@ export type GoogleTagManagerArgs = {
   environment?: string;
 }
 
+export const isValidGtmId = (tagId: string) => {
+  const pattern = /^GTM-[A-Z0-9]+$/i;
+  return pattern.test(tagId);
+}
+
 export const getIFrameURL = ({ id, server, environment, auth }: GoogleTagManagerArgs) => {
   const BASE_URL = `https://${server}/ns.html`;
 


### PR DESCRIPTION
## Fix for Cross-Site Scripting (XSS) Vulnerability

I've identified a Cross-Site Scripting (XSS) vulnerability in this package.

**Vulnerability Details:**
- **Severity**: High/Critical
- **Description**: There's a risk of malicious script execution when the ID is controlled by an adversary.

**Steps to Reproduce:**
In a React.js project:
```
import GoogleTagManager from "@magicul/next-google-tag-manager";

<GoogleTagManager id={`GTM-xxxx');alert('1`} />
```

Then the malicious code `alert(1)`  will be executed.

**Suggested Fix or Mitigation:**
Valid the GTM ID before using it in the script.

I've already fixed and tested this issue, and have submitted a pull request with the necessary changes. Please review and merge my pull request at your earliest convenience to resolve this vulnerability. Thanks!


